### PR TITLE
Enhance the security constraint to support multiple roles

### DIFF
--- a/src/main/java/org/commonjava/indy/service/security/common/SecurityConstraint.java
+++ b/src/main/java/org/commonjava/indy/service/security/common/SecurityConstraint.java
@@ -22,23 +22,23 @@ import java.util.List;
 public class SecurityConstraint
 {
 
-    private String role;
-
     private String urlPattern;
+
+    private List<String> roles;
 
     private List<String> methods;
 
-    public SecurityConstraint( String role, String urlPattern, List<String> methods )
+    public SecurityConstraint( String urlPattern, List<String> roles, List<String> methods )
     {
         super();
-        this.role = role;
         this.urlPattern = urlPattern;
+        this.roles = roles;
         this.methods = methods;
     }
 
-    public SecurityConstraint( String role, String urlPattern, String[] methods )
+    public SecurityConstraint( String urlPattern, String[] roles, String[] methods )
     {
-        this( role, urlPattern, Arrays.asList( methods ) );
+        this( urlPattern, Arrays.asList( roles ), Arrays.asList( methods ) );
     }
 
     public SecurityConstraint()
@@ -46,14 +46,14 @@ public class SecurityConstraint
         // keep default constructor
     }
 
-    public String getRole()
+    public List<String> getRoles()
     {
-        return role;
+        return roles;
     }
 
-    public void setRole( String role )
+    public void setRole( List<String> roles )
     {
-        this.role = role;
+        this.roles = roles;
     }
 
     public String getUrlPattern()
@@ -79,7 +79,7 @@ public class SecurityConstraint
     @Override
     public String toString()
     {
-        return "SecurityConstraint [role=" + role + ", urlPattern=" + urlPattern + ", methods=" + methods + "]";
+        return "SecurityConstraint [role=" + roles + ", urlPattern=" + urlPattern + ", methods=" + methods + "]";
     }
 
 }

--- a/src/main/java/org/commonjava/indy/service/security/common/SecurityManager.java
+++ b/src/main/java/org/commonjava/indy/service/security/common/SecurityManager.java
@@ -37,10 +37,6 @@ public class SecurityManager
     @Inject
     SecurityIdentity identity;
 
-//    @Inject
-//    @IdToken
-//    JsonWebToken idToken;
-
     @Inject
     SecurityBindings bindings;
 
@@ -63,18 +59,19 @@ public class SecurityManager
                               path, constraint.getUrlPattern(), pathMatched, httpMethod, methodMatched );
                 if ( pathMatched && methodMatched )
                 {
-                    if ( roles != null && !roles.isEmpty() && roles.contains( constraint.getRole() ) )
+                    for ( String role : constraint.getRoles() )
                     {
-                        logger.debug( "Role {} is allowed to access path {} through method {}", roles, path,
-                                      httpMethod );
-                        return true;
+                        if ( roles != null && !roles.isEmpty() && roles.contains( role ) )
+                        {
+                            logger.debug( "Role {} is allowed to access path {} through method {}", roles, path,
+                                          httpMethod );
+                            return true;
+                        }
                     }
-                    else
-                    {
-                        logger.warn( "Role {} is not allowed to access path {} through method {}", roles, path,
-                                     httpMethod );
-                        return false;
-                    }
+                    logger.warn( "Role {} is not allowed to access path {} through method {}", roles, path,
+                                 httpMethod );
+                    return false;
+
                 }
             }
         }

--- a/src/test/java/org/commonjava/indy/service/security/jaxrs/SecurityInResourceTest.java
+++ b/src/test/java/org/commonjava/indy/service/security/jaxrs/SecurityInResourceTest.java
@@ -71,7 +71,7 @@ public class SecurityInResourceTest
     public void testWriteStoreWithAuth1()
     {
         given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
-        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode());
+        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
         given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( NO_CONTENT.getStatusCode() );
     }
 
@@ -89,7 +89,16 @@ public class SecurityInResourceTest
     public void testWriteStoreWithWrongRole()
     {
         given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
-        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode());
+        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
         given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
+    }
+
+    @Test
+    @TestSecurity( roles = { "user", "power-user" }, user = "suser" )
+    public void testWriteStoreWithMoreRoles()
+    {
+        given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
+        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
+        given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( NO_CONTENT.getStatusCode() );
     }
 }

--- a/src/test/java/org/commonjava/indy/service/security/jaxrs/SecurityInResourceTest.java
+++ b/src/test/java/org/commonjava/indy/service/security/jaxrs/SecurityInResourceTest.java
@@ -68,19 +68,28 @@ public class SecurityInResourceTest
 
     @Test
     @TestSecurity( roles = "admin", user = "admin" )
-    public void testWriteStoreWithWrongRole()
+    public void testWriteStoreWithAuth1()
     {
-        given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
-        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
-        given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
+        given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
+        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode());
+        given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( NO_CONTENT.getStatusCode() );
     }
 
     @Test
     @TestSecurity( roles = "power-user", user = "pouser" )
-    public void testWriteStoreWithAuth()
+    public void testWriteStoreWithAuth2()
     {
         given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
         given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( CREATED.getStatusCode() );
         given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( NO_CONTENT.getStatusCode() );
+    }
+
+    @Test
+    @TestSecurity( roles = "user", user = "user" )
+    public void testWriteStoreWithWrongRole()
+    {
+        given().when().put( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
+        given().when().post( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode());
+        given().when().delete( "/api/admin/stores/testtype/test" ).then().statusCode( FORBIDDEN.getStatusCode() );
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -14,9 +14,6 @@ quarkus:
       level: INFO
     level: INFO
     min-level: TRACE
-  oidc:
-    enabled: true
-    auth-server-url: http://localhost
   devservices:
     enabled: false
   security:

--- a/src/test/resources/security-bindings.yaml
+++ b/src/test/resources/security-bindings.yaml
@@ -1,18 +1,22 @@
 constraints:
-  - role: admin
-    urlPattern: "/api/admin/.*"
+  - urlPattern: "/api/admin/.*"
+    roles:
+      - admin
     methods:
       - POST
       - PUT
       - DELETE
-  - role: user
-    urlPattern: "/api/.*"
+  - urlPattern: "/api/.*"
+    roles:
+      - user
     methods:
       - POST
       - PUT
       - DELETE
-  - role: power-user
-    urlPattern: "/api/admin/stores/.*"
+  - urlPattern: "/api/admin/stores/.*"
+    roles:
+      - power-user
+      - admin
     methods:
       - POST
       - PUT


### PR DESCRIPTION
   Sometimes for a matched paths and methods, we need to let more than
   one role to have authorization, but current way we only support one
   role. This PR will add multiple roles.